### PR TITLE
fix: impl traits on SystemTime

### DIFF
--- a/src/std.rs
+++ b/src/std.rs
@@ -126,11 +126,18 @@ pub struct SystemTime {
     inner: f64,
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct SystemTimeError(Duration);
 
 impl SystemTimeError {
     pub fn duration(&self) -> Duration {
         self.0
+    }
+}
+
+impl std::fmt::Display for SystemTimeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "second time provided was later than self")
     }
 }
 


### PR DESCRIPTION
`SystemTime` is lacking `Debug`, `Display`, `Clone` and `Copy` traits. This PR implements those.

This also by extension auto-implements `std::error::Error`.