### PR TITLE
Fix arc leak

### DIFF
--- a/examples/nodejs-example/Cargo.toml
+++ b/examples/nodejs-example/Cargo.toml
@@ -14,7 +14,7 @@ default = ["console_error_panic_hook"]
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4"
 wasmtimer = { path = "../../" }
-web-sys = {version = "0.3", features = ["console"]}
+web-sys = {version = "0.3", features = ["console", "Window", "Performance"]}
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/examples/nodejs-example/index.js
+++ b/examples/nodejs-example/index.js
@@ -13,6 +13,11 @@ import * as example from "./pkg/nodejs_example.js";
   console.log("Timeout Start JS");
   await example.timeout_test();
   console.log("Timeout Finished JS");
+
+  console.log("Arc Leak Test JS");
+  await example.arc_leak_test();
+  console.log("Arc Leak Tested JS");
+
   process.exit(0);
 })().catch((e) => {
   console.error(e);

--- a/examples/nodejs-example/src/lib.rs
+++ b/examples/nodejs-example/src/lib.rs
@@ -3,8 +3,10 @@ mod utils;
 use std::time::Duration;
 
 use wasm_bindgen::prelude::*;
-use wasmtimer::tokio::{interval, sleep, timeout};
+use wasmtimer::std::Instant;
+use wasmtimer::tokio::{interval, sleep, sleep_until, timeout};
 use web_sys::console::log_1;
+use web_sys::window;
 
 #[wasm_bindgen]
 pub async fn sleep_test() {
@@ -47,5 +49,22 @@ pub async fn timeout_test() {
                 e
             )));
         }
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["globalThis", "performance"])]
+    fn now() -> f64;
+}
+
+#[wasm_bindgen]
+pub async fn arc_leak_test() {
+    let duration = Duration::from_millis(50);
+    for _ in 0..500 {
+        let deadline = Instant::now() + duration;
+        sleep_until(deadline).await;
+        let ms = now();
+        log_1(&JsValue::from_f64(ms));
     }
 }

--- a/src/tokio_util/mod.rs
+++ b/src/tokio_util/mod.rs
@@ -21,7 +21,7 @@ fn ms(duration: Duration, round: Round) -> u64 {
 
     // Round up.
     let millis = match round {
-        Round::Up => (duration.subsec_nanos() + NANOS_PER_MILLI - 1) / NANOS_PER_MILLI,
+        Round::Up => (duration.subsec_nanos() + NANOS_PER_MILLI - 1).div_ceil(NANOS_PER_MILLI),
         Round::Down => duration.subsec_millis(),
     };
 

--- a/src/tokio_util/mod.rs
+++ b/src/tokio_util/mod.rs
@@ -21,7 +21,7 @@ fn ms(duration: Duration, round: Round) -> u64 {
 
     // Round up.
     let millis = match round {
-        Round::Up => (duration.subsec_nanos() + NANOS_PER_MILLI - 1).div_ceil(NANOS_PER_MILLI),
+        Round::Up => duration.subsec_nanos().div_ceil(NANOS_PER_MILLI),
         Round::Down => duration.subsec_millis(),
     };
 

--- a/src/tokio_util/wheel/level.rs
+++ b/src/tokio_util/wheel/level.rs
@@ -127,10 +127,7 @@ impl<T: Stack> Level<T> {
     pub(crate) fn next_expiration(&self, now: u64) -> Option<Expiration> {
         // Use the `occupied` bit field to get the index of the next slot that
         // needs to be processed.
-        let slot = match self.next_occupied_slot(now) {
-            Some(slot) => slot,
-            None => return None,
-        };
+        let slot = self.next_occupied_slot(now)?;
 
         // From the slot index, calculate the `Instant` at which it needs to be
         // processed. This value *must* be in the future with respect to `now`.


### PR DESCRIPTION
Seems to fix #22, at least for my use-case (setting a single recurring timer using iced, which internally uses `wasmtimer::tokio::interval`). 

Not really sure why this fixes it, but hopefully this is at least somewhat helpful?